### PR TITLE
Удалена возможность отправки NC-файлов

### DIFF
--- a/PyroCraft/I2GResources.es.resx
+++ b/PyroCraft/I2GResources.es.resx
@@ -126,9 +126,6 @@
   <data name="PF_Abort" xml:space="preserve">
     <value>ABORTAR</value>
   </data>
-  <data name="PF_SendingFile" xml:space="preserve">
-    <value>Enviando archivo NC...</value>
-  </data>
   <data name="PF_SendingData" xml:space="preserve">
     <value>Enviando datos...</value>
   </data>
@@ -180,20 +177,8 @@
   <data name="Menu_MachineType" xml:space="preserve">
     <value>Tipo de máquina ({0})</value>
   </data>
-  <data name="Menu_Machine" xml:space="preserve">
-    <value>Máquina</value>
-  </data>
-  <data name="Menu_SerialPort" xml:space="preserve">
-    <value>Puerto serie ({0})</value>
-  </data>
   <data name="Menu_Send" xml:space="preserve">
     <value>Enviar...</value>
-  </data>
-  <data name="Menu_SendFile" xml:space="preserve">
-    <value>Enviar archivo-NC...</value>
-  </data>
-  <data name="Menu_Configuration" xml:space="preserve">
-    <value>Configuración...</value>
   </data>
   <data name="Menu_Help" xml:space="preserve">
     <value>Ayuda</value>
@@ -411,17 +396,11 @@
   <data name="Btn_Apply" xml:space="preserve">
     <value>Aplicar</value>
   </data>
-  <data name="PF_RetrievingGrblSettings" xml:space="preserve">
-    <value>Recuperando la configuración del controlador...</value>
-  </data>
   <data name="TranslationAuthor" xml:space="preserve">
     <value>Oslay Viera</value>
   </data>
   <data name="Grbl_GCodeError" xml:space="preserve">
     <value>Algo salió mal. El controlador respondió con el código de error {0}.</value>
-  </data>
-  <data name="Grbl_GCodeErrorFile" xml:space="preserve">
-    <value>Error de código G en '{0}' cerca de la línea {1}. El controlador respondió con el código de error {2}.</value>
   </data>
   <data name="Gc_NumberOfPasses" xml:space="preserve">
     <value>Número de pases:</value>

--- a/PyroCraft/I2GResources.hu.resx
+++ b/PyroCraft/I2GResources.hu.resx
@@ -126,9 +126,6 @@
   <data name="PF_Abort" xml:space="preserve">
     <value>MEGSZAKÍT</value>
   </data>
-  <data name="PF_SendingFile" xml:space="preserve">
-    <value>NC-file küldés...</value>
-  </data>
   <data name="PF_SendingData" xml:space="preserve">
     <value>Adat küldés...</value>
   </data>
@@ -180,20 +177,8 @@
   <data name="Menu_MachineType" xml:space="preserve">
     <value>Gép típus ({0})</value>
   </data>
-  <data name="Menu_Machine" xml:space="preserve">
-    <value>Gép</value>
-  </data>
-  <data name="Menu_SerialPort" xml:space="preserve">
-    <value>Soros Port ({0})</value>
-  </data>
   <data name="Menu_Send" xml:space="preserve">
     <value>Küld...</value>
-  </data>
-  <data name="Menu_SendFile" xml:space="preserve">
-    <value>NC-fájl küldés...</value>
-  </data>
-  <data name="Menu_Configuration" xml:space="preserve">
-    <value>Konfiguráció...</value>
   </data>
   <data name="Menu_Help" xml:space="preserve">
     <value>Segítség</value>
@@ -411,17 +396,11 @@
   <data name="Btn_Apply" xml:space="preserve">
     <value>Alkalmaz</value>
   </data>
-  <data name="PF_RetrievingGrblSettings" xml:space="preserve">
-    <value>Vezérlő beállítások lekérése...</value>
-  </data>
   <data name="TranslationAuthor" xml:space="preserve">
     <value>Levente Foldes</value>
   </data>
   <data name="Grbl_GCodeError" xml:space="preserve">
     <value>Valami elromlott. A vezérlő a következő hibakóddal válaszolt {0}.</value>
-  </data>
-  <data name="Grbl_GCodeErrorFile" xml:space="preserve">
-    <value>G-kód hiba a következőben '{0}' a {1} sor közelében. A vezérlő a következő hibakóddal válaszolt {2}.</value>
   </data>
   <data name="Gc_NumberOfPasses" xml:space="preserve">
     <value>Menetek száma:</value>

--- a/PyroCraft/I2GResources.resx
+++ b/PyroCraft/I2GResources.resx
@@ -476,4 +476,7 @@
   <data name="Menu_NichromeOnOffCommand" xml:space="preserve">
     <value>Nichrome O&amp;n/Off command ({0})</value>
   </data>
+  <data name="Menu_NoPorts" xml:space="preserve">
+    <value>(No COM-ports)</value>
+  </data>
 </root>

--- a/PyroCraft/I2GResources.resx
+++ b/PyroCraft/I2GResources.resx
@@ -126,9 +126,6 @@
   <data name="PF_Abort" xml:space="preserve">
     <value>&amp;ABORT</value>
   </data>
-  <data name="PF_SendingFile" xml:space="preserve">
-    <value>Sending NC-file...</value>
-  </data>
   <data name="PF_SendingData" xml:space="preserve">
     <value>Sending data...</value>
   </data>
@@ -180,20 +177,8 @@
   <data name="Menu_MachineType" xml:space="preserve">
     <value>&amp;Machine Type ({0})</value>
   </data>
-  <data name="Menu_Machine" xml:space="preserve">
-    <value>Mac&amp;hine</value>
-  </data>
-  <data name="Menu_SerialPort" xml:space="preserve">
-    <value>Serial &amp;Port ({0})</value>
-  </data>
   <data name="Menu_Send" xml:space="preserve">
     <value>S&amp;end...</value>
-  </data>
-  <data name="Menu_SendFile" xml:space="preserve">
-    <value>Send NC-&amp;file...</value>
-  </data>
-  <data name="Menu_Configuration" xml:space="preserve">
-    <value>&amp;Configuration...</value>
   </data>
   <data name="Menu_Help" xml:space="preserve">
     <value>H&amp;elp</value>
@@ -428,14 +413,8 @@
   <data name="Btn_Apply" xml:space="preserve">
     <value>Apply</value>
   </data>
-  <data name="PF_RetrievingGrblSettings" xml:space="preserve">
-    <value>Retrieving controller settings...</value>
-  </data>
   <data name="Grbl_GCodeError" xml:space="preserve">
     <value>Something went wrong. Controller responded with error code {0}.</value>
-  </data>
-  <data name="Grbl_GCodeErrorFile" xml:space="preserve">
-    <value>G-code error in '{0}' near line {1}. Controller responded with error code {2}.</value>
   </data>
   <data name="Menu_Rotate270" xml:space="preserve">
     <value>Rotate &amp;left 90°</value>

--- a/PyroCraft/I2GResources.ro.resx
+++ b/PyroCraft/I2GResources.ro.resx
@@ -126,9 +126,6 @@
   <data name="PF_Abort" xml:space="preserve">
     <value>ÎNTRERUPE</value>
   </data>
-  <data name="PF_SendingFile" xml:space="preserve">
-    <value>Trimitere fișier NC...</value>
-  </data>
   <data name="PF_SendingData" xml:space="preserve">
     <value>Trimiterea datelor...</value>
   </data>
@@ -180,20 +177,8 @@
   <data name="Menu_MachineType" xml:space="preserve">
     <value>Tipul mașinii ({0})</value>
   </data>
-  <data name="Menu_Machine" xml:space="preserve">
-    <value>Mașina</value>
-  </data>
-  <data name="Menu_SerialPort" xml:space="preserve">
-    <value>Potrul serial ({0})</value>
-  </data>
   <data name="Menu_Send" xml:space="preserve">
     <value>Trimite...</value>
-  </data>
-  <data name="Menu_SendFile" xml:space="preserve">
-    <value>Trimitere fișier NC...</value>
-  </data>
-  <data name="Menu_Configuration" xml:space="preserve">
-    <value>Configuraţie...</value>
   </data>
   <data name="Menu_Help" xml:space="preserve">
     <value>Ajutor</value>
@@ -411,17 +396,11 @@
   <data name="Btn_Apply" xml:space="preserve">
     <value>Aplică</value>
   </data>
-  <data name="PF_RetrievingGrblSettings" xml:space="preserve">
-    <value>Se preiau setările controlerului...</value>
-  </data>
   <data name="TranslationAuthor" xml:space="preserve">
     <value>Levente Foldes</value>
   </data>
   <data name="Grbl_GCodeError" xml:space="preserve">
     <value>Ceva n-a mers bine. Controlerul a răspuns cu codul de eroare {0}.</value>
-  </data>
-  <data name="Grbl_GCodeErrorFile" xml:space="preserve">
-    <value>Eroare de cod G în '{0}' lângă linia {1}. Controlerul a răspuns cu codul de eroare {2}.</value>
   </data>
   <data name="Gc_NumberOfPasses" xml:space="preserve">
     <value>Numărul de repetare:</value>

--- a/PyroCraft/I2GResources.ru.resx
+++ b/PyroCraft/I2GResources.ru.resx
@@ -159,9 +159,6 @@
   <data name="Gc_Bidirectional" xml:space="preserve">
     <value>В обе стороны</value>
   </data>
-  <data name="Menu_Machine" xml:space="preserve">
-    <value>Станок</value>
-  </data>
   <data name="Im_Resolution" xml:space="preserve">
     <value>Разрешение картинки (DPI):</value>
   </data>
@@ -195,9 +192,6 @@
   <data name="Im_SharpenForce" xml:space="preserve">
     <value>Усиление резкости:</value>
   </data>
-  <data name="Menu_Configuration" xml:space="preserve">
-    <value>Конфигурация...</value>
-  </data>
   <data name="Menu_Reload" xml:space="preserve">
     <value>Перечитать</value>
   </data>
@@ -206,9 +200,6 @@
   </data>
   <data name="Gc_Speed" xml:space="preserve">
     <value>Скорость:</value>
-  </data>
-  <data name="PF_SendingFile" xml:space="preserve">
-    <value>Отправка NC-файла...</value>
   </data>
   <data name="Grbl_InvalidResponse" xml:space="preserve">
     <value>Некорректный ответ от контроллера!</value>
@@ -276,9 +267,6 @@
   <data name="Menu_Close" xml:space="preserve">
     <value>Закрыть</value>
   </data>
-  <data name="Menu_SerialPort" xml:space="preserve">
-    <value>COM-порт ({0})</value>
-  </data>
   <data name="Btn_SaveGCode" xml:space="preserve">
     <value>Сохранить G-код...</value>
   </data>
@@ -293,9 +281,6 @@
   </data>
   <data name="Menu_Preset" xml:space="preserve">
     <value>Пресет</value>
-  </data>
-  <data name="Menu_SendFile" xml:space="preserve">
-    <value>Отправить NC-файл...</value>
   </data>
   <data name="Grbl_NotResponding" xml:space="preserve">
     <value>Контроллер не отвечает!</value>
@@ -411,14 +396,11 @@
   <data name="Btn_Apply" xml:space="preserve">
     <value>Применить</value>
   </data>
-  <data name="PF_RetrievingGrblSettings" xml:space="preserve">
-    <value>Получение настроек контроллера...</value>
+  <data name="Menu_NoPorts" xml:space="preserve">
+    <value>(Нету COM-портов)</value>
   </data>
   <data name="Grbl_GCodeError" xml:space="preserve">
     <value>Что-то пошло не так. Контроллер ответил кодом ошибки {0}.</value>
-  </data>
-  <data name="Grbl_GCodeErrorFile" xml:space="preserve">
-    <value>Ошибка G-кода в файле '{0}' на строке {1}. Контроллер ответил кодом ошибки {2}.</value>
   </data>
   <data name="Gc_NumberOfPasses" xml:space="preserve">
     <value>Кол-во проходов:</value>

--- a/PyroCraft/I2GResources.uk.resx
+++ b/PyroCraft/I2GResources.uk.resx
@@ -141,12 +141,6 @@
   <data name="Menu_SaveImage" xml:space="preserve">
     <value>Зберегти копію як...</value>
   </data>
-  <data name="Menu_Machine" xml:space="preserve">
-    <value>Станок</value>
-  </data>
-  <data name="Menu_SerialPort" xml:space="preserve">
-    <value>COM-порт ({0})</value>
-  </data>
   <data name="Menu_Send" xml:space="preserve">
     <value>Відправити...</value>
   </data>

--- a/PyroCraft/PyroCraft.Designer.cs
+++ b/PyroCraft/PyroCraft.Designer.cs
@@ -75,8 +75,6 @@ partial class PyroCraft {
         this.burnFromBottomToTopToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
         this.doNotReturnYToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
         this.toolStripSeparator13 = new System.Windows.Forms.ToolStripSeparator();
-        this.machineToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-        this.portToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
         this.sendToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
         this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
         this.helpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -88,7 +86,7 @@ partial class PyroCraft {
         this.toolStrip1 = new System.Windows.Forms.ToolStrip();
         this.openToolStripButton = new System.Windows.Forms.ToolStripButton();
         this.exportToolStripButton = new System.Windows.Forms.ToolStripButton();
-        this.sendToolStripButton = new System.Windows.Forms.ToolStripButton();
+        this.sendToolStripButton = new System.Windows.Forms.ToolStripSplitButton();
         this.statusStrip1 = new System.Windows.Forms.StatusStrip();
         this.toolStripStatusLabel1 = new System.Windows.Forms.ToolStripStatusLabel();
         this.toolStripStatusLabel6 = new System.Windows.Forms.ToolStripStatusLabel();
@@ -291,7 +289,6 @@ partial class PyroCraft {
                         this.fileToolStripMenuItem,
                         this.imageToolStripMenuItem,
                         this.presetToolStripMenuItem,
-                        this.machineToolStripMenuItem,
                         this.helpToolStripMenuItem});
         this.menuStrip1.RenderMode = System.Windows.Forms.ToolStripRenderMode.Professional;
         this.menuStrip1.TabIndex = 0;
@@ -311,6 +308,7 @@ partial class PyroCraft {
                         this.toolStripSeparator6,
                         this.exitToolStripMenuItem});
         this.fileToolStripMenuItem.Text = "&File";
+        this.fileToolStripMenuItem.DropDownClosed += new System.EventHandler(this.FileToolStripMenuItemDropDownClosed);
         this.fileToolStripMenuItem.DropDownOpening += new System.EventHandler(this.FileToolStripMenuItemDropDownOpening);
         // 
         // openToolStripMenuItem
@@ -695,20 +693,6 @@ partial class PyroCraft {
         this.doNotReturnYToolStripMenuItem.Text = "Do not return Y to O&rigin";
         this.doNotReturnYToolStripMenuItem.Click += new System.EventHandler(this.DoNotReturnYToolStripMenuItemClick);
         // 
-        // machineToolStripMenuItem
-        // 
-        this.machineToolStripMenuItem.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-        this.machineToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-                        this.portToolStripMenuItem});
-        this.machineToolStripMenuItem.Text = "Mac&hine";
-        this.machineToolStripMenuItem.DropDownOpening += new System.EventHandler(this.MachineToolStripMenuItemDropDownOpening);
-        // 
-        // portToolStripMenuItem
-        // 
-        this.portToolStripMenuItem.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-        this.portToolStripMenuItem.Text = "Serial &Port";
-        this.portToolStripMenuItem.DropDownItemClicked += new System.Windows.Forms.ToolStripItemClickedEventHandler(this.PortToolStripMenuItemDropDownItemClicked);
-        // 
         // sendToolStripMenuItem
         // 
         this.sendToolStripMenuItem.Enabled = false;
@@ -716,6 +700,7 @@ partial class PyroCraft {
         this.sendToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.P)));
         this.sendToolStripMenuItem.Text = "S&end...";
         this.sendToolStripMenuItem.Click += new System.EventHandler(this.SendToolStripMenuItemClick);
+        this.sendToolStripMenuItem.DropDownItemClicked += new System.Windows.Forms.ToolStripItemClickedEventHandler(this.SendToolStripMenuItemDropDownItemClicked);
         // 
         // helpToolStripMenuItem
         // 
@@ -788,7 +773,9 @@ partial class PyroCraft {
         this.sendToolStripButton.ImageTransparentColor = System.Drawing.Color.Magenta;
         this.sendToolStripButton.Padding = new System.Windows.Forms.Padding(2, 0, 2, 0);
         this.sendToolStripButton.Text = "Send...";
-        this.sendToolStripButton.Click += new System.EventHandler(this.SendToolStripMenuItemClick);
+        this.sendToolStripButton.ButtonClick += new System.EventHandler(this.SendToolStripMenuItemClick);
+        this.sendToolStripButton.DropDownItemClicked += new System.Windows.Forms.ToolStripItemClickedEventHandler(this.SendToolStripMenuItemDropDownItemClicked);
+        this.sendToolStripButton.DropDownOpening += new System.EventHandler(this.SendToolStripMenuItemDropDownOpening);
         // 
         // statusStrip1
         // 
@@ -2909,7 +2896,7 @@ partial class PyroCraft {
     private System.Windows.Forms.TableLayoutPanel tableLayoutPanel4;
     private System.Windows.Forms.TableLayoutPanel tableLayoutPanel3;
     private System.Windows.Forms.TableLayoutPanel tableLayoutPanel2;
-    private System.Windows.Forms.ToolStripButton sendToolStripButton;
+    private System.Windows.Forms.ToolStripSplitButton sendToolStripButton;
     private System.Windows.Forms.ToolStripButton exportToolStripButton;
     private System.Windows.Forms.ToolStripButton openToolStripButton;
     private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
@@ -2921,7 +2908,6 @@ partial class PyroCraft {
     private System.Windows.Forms.ToolStripSeparator toolStripSeparator5;
     private System.Windows.Forms.ToolStripSeparator toolStripSeparator3;
     private System.Windows.Forms.ToolStripMenuItem sendToolStripMenuItem;
-    private System.Windows.Forms.ToolStripMenuItem portToolStripMenuItem;
     private System.Windows.Forms.ToolStripMenuItem cropToolStripMenuItem;
     private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
     private System.Windows.Forms.ToolStripMenuItem saveToolStripMenuItem;
@@ -2933,7 +2919,6 @@ partial class PyroCraft {
     private System.Windows.Forms.ToolStripMenuItem reloadToolStripMenuItem;
     private System.Windows.Forms.ToolStripMenuItem openToolStripMenuItem;
     private System.Windows.Forms.ToolStripMenuItem helpToolStripMenuItem;
-    private System.Windows.Forms.ToolStripMenuItem machineToolStripMenuItem;
     private System.Windows.Forms.ToolStripMenuItem imageToolStripMenuItem;
     private System.Windows.Forms.ToolStripMenuItem fileToolStripMenuItem;
     private System.Windows.Forms.MenuStrip menuStrip1;

--- a/PyroCraft/PyroCraft.Designer.cs
+++ b/PyroCraft/PyroCraft.Designer.cs
@@ -79,7 +79,6 @@ partial class PyroCraft {
         this.portToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
         this.sendToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
         this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
-        this.uploadToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
         this.helpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
         this.websiteToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
         this.toolStripSeparator5 = new System.Windows.Forms.ToolStripSeparator();
@@ -237,7 +236,6 @@ partial class PyroCraft {
         this.saveFileDialog1 = new System.Windows.Forms.SaveFileDialog();
         this.saveFileDialog2 = new System.Windows.Forms.SaveFileDialog();
         this.backgroundWorker1 = new System.ComponentModel.BackgroundWorker();
-        this.openFileDialog2 = new System.Windows.Forms.OpenFileDialog();
         this.backgroundWorker2 = new System.ComponentModel.BackgroundWorker();
         this.serialPort1 = new System.IO.Ports.SerialPort(this.components);
         this.menuStrip1.SuspendLayout();
@@ -307,6 +305,8 @@ partial class PyroCraft {
                         this.exportToolStripMenuItem,
                         this.closeToolStripMenuItem,
                         this.toolStripSeparator1,
+                        this.sendToolStripMenuItem,
+                        this.toolStripSeparator3,
                         this.languageToolStripMenuItem,
                         this.toolStripSeparator6,
                         this.exitToolStripMenuItem});
@@ -699,10 +699,7 @@ partial class PyroCraft {
         // 
         this.machineToolStripMenuItem.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
         this.machineToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-                        this.portToolStripMenuItem,
-                        this.sendToolStripMenuItem,
-                        this.toolStripSeparator3,
-                        this.uploadToolStripMenuItem});
+                        this.portToolStripMenuItem});
         this.machineToolStripMenuItem.Text = "Mac&hine";
         this.machineToolStripMenuItem.DropDownOpening += new System.EventHandler(this.MachineToolStripMenuItemDropDownOpening);
         // 
@@ -719,13 +716,6 @@ partial class PyroCraft {
         this.sendToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.P)));
         this.sendToolStripMenuItem.Text = "S&end...";
         this.sendToolStripMenuItem.Click += new System.EventHandler(this.SendToolStripMenuItemClick);
-        // 
-        // uploadToolStripMenuItem
-        // 
-        this.uploadToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("uploadToolStripMenuItem.Image")));
-        this.uploadToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift | System.Windows.Forms.Keys.O)));
-        this.uploadToolStripMenuItem.Text = "Send NC-&file...";
-        this.uploadToolStripMenuItem.Click += new System.EventHandler(this.UploadToolStripMenuItemClick);
         // 
         // helpToolStripMenuItem
         // 
@@ -2612,11 +2602,6 @@ partial class PyroCraft {
         this.backgroundWorker1.ProgressChanged += new System.ComponentModel.ProgressChangedEventHandler(this.BackgroundWorker1ProgressChanged);
         this.backgroundWorker1.RunWorkerCompleted += new System.ComponentModel.RunWorkerCompletedEventHandler(this.BackgroundWorker1RunWorkerCompleted);
         // 
-        // openFileDialog2
-        // 
-        this.openFileDialog2.DefaultExt = "nc";
-        this.openFileDialog2.Filter = "All files (*.*)|*.*";
-        // 
         // backgroundWorker2
         // 
         this.backgroundWorker2.WorkerReportsProgress = true;
@@ -2803,7 +2788,6 @@ partial class PyroCraft {
     private System.Windows.Forms.TableLayoutPanel tableLayoutPanel33;
     private System.Windows.Forms.Label button29;
     private System.Windows.Forms.TableLayoutPanel tableLayoutPanel32;
-    private System.Windows.Forms.OpenFileDialog openFileDialog2;
     private System.Windows.Forms.ToolStripSeparator toolStripSeparator7;
     private System.Windows.Forms.Button button22;
     private System.Windows.Forms.Button button21;
@@ -2935,7 +2919,6 @@ partial class PyroCraft {
     private System.Windows.Forms.ToolStripMenuItem websiteToolStripMenuItem;
     private System.Windows.Forms.ToolStripMenuItem aboutToolStripMenuItem;
     private System.Windows.Forms.ToolStripSeparator toolStripSeparator5;
-    private System.Windows.Forms.ToolStripMenuItem uploadToolStripMenuItem;
     private System.Windows.Forms.ToolStripSeparator toolStripSeparator3;
     private System.Windows.Forms.ToolStripMenuItem sendToolStripMenuItem;
     private System.Windows.Forms.ToolStripMenuItem portToolStripMenuItem;

--- a/PyroCraft/PyroCraft.cs
+++ b/PyroCraft/PyroCraft.cs
@@ -95,7 +95,6 @@ partial class PyroCraft:Form {
     private int activePreset;
     
     private bool bWorker2SendToDevice;
-    private bool bWorker2ReadFromFile;
     
     private bool bWorkerIsBusy = true;
     
@@ -133,7 +132,6 @@ partial class PyroCraft:Form {
         InitializeComponent();
         
         openFileDialog1.Title = AppTitle;
-        openFileDialog2.Title = AppTitle;
         saveFileDialog1.Title = AppTitle;
         saveFileDialog2.Title = AppTitle;
         
@@ -818,7 +816,6 @@ partial class PyroCraft:Form {
         progressForm1.progressBar1.Value = 0;
         
         bWorker2SendToDevice = false;
-        bWorker2ReadFromFile = false;
         
         progressForm1.ShowDialog(this);
     }
@@ -832,22 +829,6 @@ partial class PyroCraft:Form {
         progressForm1.progressBar1.Value = 0;
         
         bWorker2SendToDevice = true;
-        bWorker2ReadFromFile = false;
-        
-        progressForm1.ShowDialog(this);
-    }
-    
-    private void UploadToolStripMenuItemClick(object sender, EventArgs e) {
-        openFileDialog2.FileName = null;
-        if (openFileDialog2.ShowDialog(this) != DialogResult.OK) {
-            return;
-        }
-        
-        progressForm1.label1.Text = resources.GetString("PF_Initializing", culture);
-        progressForm1.progressBar1.Value = 0;
-        
-        bWorker2SendToDevice = true;
-        bWorker2ReadFromFile = true;
         
         progressForm1.ShowDialog(this);
     }
@@ -898,7 +879,6 @@ partial class PyroCraft:Form {
         this.doNotReturnYToolStripMenuItem.Text = resources.GetString("Menu_DoNotReturnY", culture);
         this.machineToolStripMenuItem.Text = resources.GetString("Menu_Machine", culture);
         this.sendToolStripMenuItem.Text = resources.GetString("Menu_Send", culture);
-        this.uploadToolStripMenuItem.Text = resources.GetString("Menu_SendFile", culture);
         this.helpToolStripMenuItem.Text = resources.GetString("Menu_Help", culture);
         this.websiteToolStripMenuItem.Text = resources.GetString("Menu_Website", culture);
         this.CH341SERToolStripMenuItem.Text = resources.GetString("Menu_DownloadCH340Driver", culture);

--- a/PyroCraft/PyroCraft.cs
+++ b/PyroCraft/PyroCraft.cs
@@ -596,10 +596,16 @@ partial class PyroCraft:Form {
     }
     
     private void FileToolStripMenuItemDropDownOpening(object sender, EventArgs e) {
+        SendToolStripMenuItemDropDownOpening(sendToolStripMenuItem, null);
+        
         int lcid = culture.LCID;
         foreach (ToolStripMenuItem toolStripItem in languageToolStripMenuItem.DropDownItems) {
             toolStripItem.Checked = ((int)toolStripItem.Tag == lcid);
         }
+    }
+    
+    private void FileToolStripMenuItemDropDownClosed(object sender, EventArgs e) {
+        sendToolStripMenuItem.DropDownItems.Clear();
     }
     
     private void LanguageToolStripMenuItemDropDownItemClicked(object sender, ToolStripItemClickedEventArgs e) {
@@ -777,30 +783,32 @@ partial class PyroCraft:Form {
         gcDontReturnY = !gcDontReturnY;
     }
     
-    private void MachineToolStripMenuItemDropDownOpening(object sender, EventArgs e) {
+    private void SendToolStripMenuItemDropDownOpening(object sender, EventArgs e) {
         string[] portNames = SerialPort.GetPortNames();
         
-        portToolStripMenuItem.Text = String.Format(culture, resources.GetString("Menu_SerialPort", culture), comPort);
+        ((ToolStripDropDownItem)sender).DropDownItems.Clear();
         if (portNames.Length > 0) {
-            portToolStripMenuItem.Enabled = true;
+            foreach (string portName in portNames) {
+                ToolStripMenuItem toolStripItem = new ToolStripMenuItem();
+                toolStripItem.DisplayStyle = ToolStripItemDisplayStyle.Text;
+                toolStripItem.Text = portName;
+                toolStripItem.Checked = (portName == comPort);
+                
+                ((ToolStripDropDownItem)sender).DropDownItems.Add(toolStripItem);
+            }
         } else {
-            portToolStripMenuItem.Enabled = false;
-            portNames = new string[] { "COM1", };
-        }
-        
-        portToolStripMenuItem.DropDownItems.Clear();
-        foreach (string portName in portNames) {
             ToolStripMenuItem toolStripItem = new ToolStripMenuItem();
             toolStripItem.DisplayStyle = ToolStripItemDisplayStyle.Text;
-            toolStripItem.Text = portName;
-            toolStripItem.Checked = (portName == comPort);
+            toolStripItem.Text = resources.GetString("Menu_NoPorts", culture);
+            toolStripItem.Enabled = false;
             
-            portToolStripMenuItem.DropDownItems.Add(toolStripItem);
+            ((ToolStripDropDownItem)sender).DropDownItems.Add(toolStripItem);
         }
     }
     
-    private void PortToolStripMenuItemDropDownItemClicked(object sender, ToolStripItemClickedEventArgs e) {
+    private void SendToolStripMenuItemDropDownItemClicked(object sender, ToolStripItemClickedEventArgs e) {
         comPort = e.ClickedItem.Text;
+        SendToolStripMenuItemClick(sender, null);
     }
     
     private void ExportToolStripMenuItemClick(object sender, EventArgs e) {
@@ -877,7 +885,6 @@ partial class PyroCraft:Form {
         this.defaultToolStripMenuItem2.Text = resources.GetString("Menu_GraphLinear", culture);
         this.burnFromBottomToTopToolStripMenuItem.Text = resources.GetString("Menu_BurnFromBottomToTop", culture);
         this.doNotReturnYToolStripMenuItem.Text = resources.GetString("Menu_DoNotReturnY", culture);
-        this.machineToolStripMenuItem.Text = resources.GetString("Menu_Machine", culture);
         this.sendToolStripMenuItem.Text = resources.GetString("Menu_Send", culture);
         this.helpToolStripMenuItem.Text = resources.GetString("Menu_Help", culture);
         this.websiteToolStripMenuItem.Text = resources.GetString("Menu_Website", culture);

--- a/PyroCraft/PyroCraft.resx
+++ b/PyroCraft/PyroCraft.resx
@@ -215,14 +215,6 @@
         88RiDLQqWnsBm1zRlmSsNt8AAAAASUVORK5CYII=
 </value>
   </data>
-  <data name="uploadToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAKZJREFUOE9j
-        QAcODg77HB0d/2PB34ByCVBlOAEjSDGUjQzA4kD8z8nJKQMqhhUQMoCgIcQYAMJ/cXmHWANA+CtYBsh4
-        BRX4BlMIliAAgOr+wRgwEwfWgH/u7u5CYAFSAcwAKJd0gGwAkLaH8onFD1EMACaQBiRJYvBxdBccgPKJ
-        wkALe+AG2NnZqQLp7zBJInEwzACysK2trSTIgNfoEkTiiwwMDAwAiavu/4mY4+oAAAAASUVORK5CYII=
-</value>
-  </data>
   <data name="aboutToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAQpJREFUOE9j
@@ -265,7 +257,7 @@
         AAEAAAD/////AQAAAAAAAAAMAgAAAFdTeXN0ZW0uV2luZG93cy5Gb3JtcywgVmVyc2lvbj00LjAuMC4w
         LCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODkFAQAAACZTeXN0
         ZW0uV2luZG93cy5Gb3Jtcy5JbWFnZUxpc3RTdHJlYW1lcgEAAAAERGF0YQcCAgAAAAkDAAAADwMAAADG
-        CQAAAk1TRnQBSQFMAgEBAgEAASgBAAEsAQABCQEAARgBAAT/AQkBEAj/AUIBTQE2AQQGAAE2AQQCAAEo
+        CQAAAk1TRnQBSQFMAgEBAgEAASgBAAEwAQABCQEAARgBAAT/AQkBEAj/AUIBTQE2AQQGAAE2AQQCAAEo
         AwABJAMAARgDAAEBAQABCAUAAWABAxgAAYACAAGAAwACgAEAAYADAAGAAQABgAEAAoACAAPAAQABwAHc
         AcABAAHwAcoBpgEAATMFAAEzAQABMwEAATMBAAIzAgADFgEAAxwBAAMiAQADKQEAA1UBAANNAQADQgEA
         AzkBAAGAAXwB/wEAAlAB/wEAAZMBAAHWAQAB/wHsAcwBAAHGAdYB7wEAAdYC5wEAAZABqQGtAgAB/wEz
@@ -468,9 +460,6 @@
   </metadata>
   <metadata name="backgroundWorker1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>283, 17</value>
-  </metadata>
-  <metadata name="openFileDialog2.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>150, 17</value>
   </metadata>
   <metadata name="backgroundWorker2.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>541, 17</value>


### PR DESCRIPTION
Функция отправки NC-файлов была предназначена исключительно для отправки G-кода созданного в сторонних программах на ЧПУ контроллер КАСКАД. Это-же программа для выжигания картинок - ненужно делать все-все в одной программе. Для отправки NC-файлов есть отдельные утилиты и программы.

Так-же объединил меню выбора COM-порта с кнопкой Отправить. Меню Станок удалено.